### PR TITLE
Improve trigger styling and add showLabel() option

### DIFF
--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -1,19 +1,24 @@
 <div @if($floating ?? false) style="position: fixed; top: 0.5rem; right: 1rem; z-index: 50;" @endif>
     <x-filament::dropdown placement="bottom-end" maxHeight="36rem" teleport>
-        <x-slot name="trigger" style="justify-self: center; align-self: center; padding: 0.5rem 0;">
+        <x-slot name="trigger" style="justify-self: center; align-self: center;">
             @if (isset($currentLanguage) && $showFlags)
-                <div style="width: 2rem; height: 2rem; border-radius: 9999px; overflow: hidden; cursor: pointer;">
-                    @php
-                        try {
-                            echo svg('flag-1x1-'.$currentLanguage['flag'], '')->toHtml();
-                            $flagFound = true;
-                        } catch (Exception) {
-                            $flagFound = false;
-                        }
-                    @endphp
-                    @unless ($flagFound)
-                        <x-filament::icon icon="heroicon-o-language" style="width: 2rem; height: 2rem;" />
-                    @endunless
+                <div style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer; padding: 0.25rem 0.5rem;">
+                    <div style="width: 1.5rem; height: 1.5rem; border-radius: 9999px; overflow: hidden; flex-shrink: 0;">
+                        @php
+                            try {
+                                echo svg('flag-1x1-'.$currentLanguage['flag'], '')->toHtml();
+                                $flagFound = true;
+                            } catch (Exception) {
+                                $flagFound = false;
+                            }
+                        @endphp
+                        @unless ($flagFound)
+                            <x-filament::icon icon="heroicon-o-language" style="width: 1.5rem; height: 1.5rem;" />
+                        @endunless
+                    </div>
+                    @if ($showLabel)
+                        <span style="font-size: 0.875rem;">{{ $currentLanguage['name'] }}</span>
+                    @endif
                 </div>
             @else
                 <x-filament::icon-button icon="heroicon-o-language" label="Language switcher"/>

--- a/src/FilamentLanguageSwitcherPlugin.php
+++ b/src/FilamentLanguageSwitcherPlugin.php
@@ -17,6 +17,7 @@ class FilamentLanguageSwitcherPlugin implements Plugin
 
     protected array|Closure $locales = [];
     protected bool $showFlags = true;
+    protected bool $showLabel = false;
     protected bool $showOnAuthPages = false;
     protected string $renderHook = PanelsRenderHook::USER_MENU_BEFORE;
 
@@ -39,6 +40,12 @@ class FilamentLanguageSwitcherPlugin implements Plugin
     public function showFlags(bool $show = true): static
     {
         $this->showFlags = $show;
+        return $this;
+    }
+
+    public function showLabel(bool $show = true): static
+    {
+        $this->showLabel = $show;
         return $this;
     }
 
@@ -101,11 +108,13 @@ class FilamentLanguageSwitcherPlugin implements Plugin
         $currentLanguage = collect($locales)->firstWhere('code', $currentLocale);
         $otherLanguages = $locales;
         $showFlags = $this->showFlags;
+        $showLabel = $this->showLabel;
 
         return view('filament-language-switcher::language-switcher', compact(
             'otherLanguages',
             'currentLanguage',
             'showFlags',
+            'showLabel',
             'floating',
         ));
     }


### PR DESCRIPTION
## Summary
- Adjust trigger height and padding to match surrounding menu items (e.g. user menu entries)
- Add `->showLabel()` plugin option to optionally display the language name next to the flag

## Usage
```php
FilamentLanguageSwitcherPlugin::make()
    ->showLabel()
```
<img width="245" height="179" alt="SCR-20260323-pphi-2" src="https://github.com/user-attachments/assets/54608c13-0a63-428a-babe-e46799187cdf" />
<img width="256" height="180" alt="SCR-20260323-powf" src="https://github.com/user-attachments/assets/83f22893-11ac-4df7-b97c-4a87ec70c92d" />

