### PR TITLE
Add flagMapping() option to remap flag icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ FilamentLanguageSwitcherPlugin::make()
     ->showOnAuthPages()
 ```
 
+### Flag Mapping
+
+Remap flag icons for specific locales — useful when a language's default flag doesn't match your audience (e.g. show the Swiss flag for German):
+```php
+FilamentLanguageSwitcherPlugin::make()
+    ->flagMapping(['de' => 'ch', 'fr' => 'be'])
+```
+
+Flag codes reference: https://flagicons.lipis.dev
+
 ### Hide Flags
 
 Display only language names without flag icons:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ FilamentLanguageSwitcherPlugin::make()
 
 Flag codes reference: https://flagicons.lipis.dev
 
+### Show Label
+
+Display the current language name next to the flag in the trigger button:
+```php
+FilamentLanguageSwitcherPlugin::make()
+    ->showLabel()
+```
+
 ### Hide Flags
 
 Display only language names without flag icons:

--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -1,19 +1,24 @@
 <div @if($floating ?? false) style="position: fixed; top: 0.5rem; right: 1rem; z-index: 50;" @endif>
     <x-filament::dropdown placement="bottom-end" maxHeight="36rem" teleport>
-        <x-slot name="trigger" style="justify-self: center; align-self: center; padding: 0.5rem 0;">
+        <x-slot name="trigger" style="justify-self: center; align-self: center;">
             @if (isset($currentLanguage) && $showFlags)
-                <div style="width: 2rem; height: 2rem; border-radius: 9999px; overflow: hidden; cursor: pointer;">
-                    @php
-                        try {
-                            echo svg('flag-1x1-'.$currentLanguage['flag'], '')->toHtml();
-                            $flagFound = true;
-                        } catch (Exception) {
-                            $flagFound = false;
-                        }
-                    @endphp
-                    @unless ($flagFound)
-                        <x-filament::icon icon="heroicon-o-language" style="width: 2rem; height: 2rem;" />
-                    @endunless
+                <div style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer; padding: 0.25rem 0.5rem;">
+                    <div style="width: 1.5rem; height: 1.5rem; border-radius: 9999px; overflow: hidden; flex-shrink: 0;">
+                        @php
+                            try {
+                                echo svg('flag-1x1-'.$currentLanguage['flag'], '')->toHtml();
+                                $flagFound = true;
+                            } catch (Exception) {
+                                $flagFound = false;
+                            }
+                        @endphp
+                        @unless ($flagFound)
+                            <x-filament::icon icon="heroicon-o-language" style="width: 1.5rem; height: 1.5rem;" />
+                        @endunless
+                    </div>
+                    @if ($showLabel)
+                        <span style="font-size: 0.875rem;">{{ $currentLanguage['name'] }}</span>
+                    @endif
                 </div>
             @else
                 <x-filament::icon-button icon="heroicon-o-language" label="Language switcher"/>

--- a/src/FilamentLanguageSwitcherPlugin.php
+++ b/src/FilamentLanguageSwitcherPlugin.php
@@ -17,6 +17,7 @@ class FilamentLanguageSwitcherPlugin implements Plugin
 
     protected array|Closure $locales = [];
     protected bool $showFlags = true;
+    protected bool $showLabel = false;
     protected bool $showOnAuthPages = false;
     protected string $renderHook = PanelsRenderHook::USER_MENU_BEFORE;
 
@@ -39,6 +40,12 @@ class FilamentLanguageSwitcherPlugin implements Plugin
     public function showFlags(bool $show = true): static
     {
         $this->showFlags = $show;
+        return $this;
+    }
+
+    public function showLabel(bool $show = true): static
+    {
+        $this->showLabel = $show;
         return $this;
     }
 
@@ -101,11 +108,13 @@ class FilamentLanguageSwitcherPlugin implements Plugin
         $currentLanguage = collect($locales)->firstWhere('code', $currentLocale);
         $otherLanguages = $locales;
         $showFlags = $this->showFlags;
+        $showLabel = $this->showLabel;
 
         return view('filament-language-switcher::language-switcher', compact(
             'otherLanguages',
             'currentLanguage',
             'showFlags',
+            'showLabel',
             'floating',
         ));
     }

--- a/src/FilamentLanguageSwitcherPlugin.php
+++ b/src/FilamentLanguageSwitcherPlugin.php
@@ -19,6 +19,7 @@ class FilamentLanguageSwitcherPlugin implements Plugin
     protected bool $showFlags = true;
     protected bool $showLabel = false;
     protected bool $showOnAuthPages = false;
+    protected array $flagMapping = [];
     protected string $renderHook = PanelsRenderHook::USER_MENU_BEFORE;
 
     public function getId(): string
@@ -62,6 +63,16 @@ class FilamentLanguageSwitcherPlugin implements Plugin
     public function rememberLocale(?int $days = null): static
     {
         static::$rememberLocaleDays = $days ?? 0;
+        return $this;
+    }
+
+    /**
+     * Remap flag codes for specific locales.
+     * e.g. ['de' => 'ch'] will show the Swiss flag for the German locale.
+     */
+    public function flagMapping(array $mapping): static
+    {
+        $this->flagMapping = $mapping;
         return $this;
     }
 
@@ -150,6 +161,10 @@ class FilamentLanguageSwitcherPlugin implements Plugin
                     $locale['flag'] = $this->getCountryCode($locale['code']);
                 }
 
+                if (isset($this->flagMapping[$locale['code']])) {
+                    $locale['flag'] = $this->flagMapping[$locale['code']];
+                }
+
                 return $locale;
             }, $locales);
         }
@@ -176,10 +191,14 @@ class FilamentLanguageSwitcherPlugin implements Plugin
                 continue;
             }
 
+            $flag = isset($this->flagMapping[$localeCode])
+                ? $this->flagMapping[$localeCode]
+                : $this->getCountryCode($localeCode);
+
             $locales[] = [
                 'code' => $localeCode,
                 'name' => $this->getLanguageName($localeCode),
-                'flag' => $this->getCountryCode($localeCode),
+                'flag' => $flag,
             ];
         }
 


### PR DESCRIPTION
## Summary
- Adds a new `flagMapping()` fluent method to remap flag icons for specific locales (e.g. `['de' => 'ch']` to show the Swiss flag for German)
- Applies to both explicitly configured locales and auto-detected Filament locales
- Consistent with existing option methods (`showFlags()`, `showLabel()`, etc.)

## Usage
```php
FilamentLanguageSwitcherPlugin::make()
    ->locales(['en', 'de', 'fr'])
    ->flagMapping(['de' => 'ch'])
```